### PR TITLE
Update to enable filtering admin dashboard based on permissions

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+REACT_APP_TMDB_API_KEY=13d641af6d4e99c9aa454aed895411cf
+REACT_APP_TMDB_API=https://api.themoviedb.org/3

--- a/src/components/header/NavBar.tsx
+++ b/src/components/header/NavBar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import {
@@ -14,10 +14,13 @@ import CreatePost from '../main/Create/CreatePost';
 import { setCurrentUser } from '../main/Account/reducer';
 import { useDispatch, useSelector } from 'react-redux';
 
+import * as userClient from '../../services/userService';
+
 export default function NavBar() {
   const { pathname } = useLocation();
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const [userRole, setUserRole] = useState('');
 
   const { currentUser } = useSelector((state: any) => state.accounts);
 
@@ -27,7 +30,7 @@ export default function NavBar() {
     { label: 'COLLECTIONS', path: '/collections', icon: null },
     { label: '', path: '/news', icon: <CiBullhorn className="icon" /> },
     { label: '', path: '/profile', icon: <CiUser className="icon" /> },
-    { label: '', path: '/admin', icon: <MdAdminPanelSettings className="icon" /> },
+    ...(currentUser !== null && currentUser.role === 'ADMIN' ? [{ label: '', path: '/admin', icon: <MdAdminPanelSettings className="icon" /> }] : [])
   ];
 
   const handleSignOut = () => {

--- a/src/components/main/Admin/index.css
+++ b/src/components/main/Admin/index.css
@@ -24,8 +24,8 @@ h2 {
 
 table {
   width: 100%;
-  border-collapse: collapse;
   font-family: var(--font-main);
+  table-layout: fixed;
 }
 
 select {
@@ -40,7 +40,7 @@ select {
 th,
 td {
   padding: 8px;
-  border: 1px solid #ddd;
+  border: none;
   text-align: left;
 }
 
@@ -94,6 +94,27 @@ button:hover {
   display: flex;
   justify-content: center;
   align-items: center;
+}
+
+.modal-content {
+  background-color: var(--color-background1);
+  padding: 20px;
+  border-radius: 5px;
+  text-align: center;
+  width: 50%;
+}
+
+.modal-content button {
+  background-color: var(--color-button);
+  color: var(--color-text);
+  padding: 5px 10px;
+  margin-top: 10px;
+  font-size: 16px;
+  font-weight: bold;
+  text-transform: uppercase;
+  text-decoration: none;
+  border-radius: 25px;
+  height: 45px;
 }
 
 @media (max-width: 1100px) {

--- a/src/components/main/Admin/index.tsx
+++ b/src/components/main/Admin/index.tsx
@@ -103,12 +103,15 @@ export default function Admin() {
   if (isLoading) return <div>Loading...</div>;
   if (error) return <div>Error: {error}</div>;
 
+  const canManageUsers = adminPermissions.includes('manage_users');
+  const canManageContent = adminPermissions.includes('manage_content');
+
   return (
     <div className="admin-dashboard">
       <h1>Admin Dashboard</h1>
       <div className="dashboard-content">
-        {adminPermissions.includes('manage_users') && (
-          <div className="dashboard-column">
+        {canManageUsers && (
+          <div className={`dashboard-column ${(canManageUsers && canManageContent) ? '' : 'single-column'}`}>
             <h2>Users</h2>
             <table className='user-table'>
               <thead>
@@ -155,8 +158,8 @@ export default function Admin() {
             </table>
           </div>
         )}
-        {adminPermissions.includes('manage_content') && (
-          <div className="dashboard-column">
+        {canManageContent && (
+          <div className={`dashboard-column ${(canManageUsers && canManageContent) ? '' : 'single-column'}`}>
             <h2>Reviews</h2>
             <table className='reviews-table'>
               <thead>

--- a/src/components/main/Admin/index.tsx
+++ b/src/components/main/Admin/index.tsx
@@ -3,32 +3,40 @@ import React, { useState, useEffect, useMemo } from 'react';
 import * as movieClient from '../../../services/movieService';
 import * as userClient from '../../../services/userService';
 import * as reviewClient from '../../../services/reviewService';
+import * as adminClient from '../../../services/adminService';
 
 import './index.css'
+import { useSelector } from 'react-redux';
 
 export default function Admin() {
 
   const [users, setUsers] = useState<any[]>([]);
   const [reviews, setReviews] = useState<any[]>([]);
-  const [movies, setMovies] = useState<any[]>([]);
   const [activeTab, setActiveTab] = useState('users');
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [confirmAction, setConfirmAction] = useState<{ action: () => void, message: string } | null>(null);
+  const [adminPermissions, setAdminPermissions] = useState<string[]>([]);
+
+  const { currentUser } = useSelector((state: any) => state.accounts);
 
   const fetchData = async () => {
+
     setIsLoading(true);
     setError(null);
     try {
-      const [usersRes, reviewsRes, moviesRes] = await Promise.all([
+      if (currentUser) {
+        const admin = await adminClient.findAdminByUserId(currentUser._id);
+        setAdminPermissions(admin.permissions);
+      }
+
+      const [usersRes, reviewsRes] = await Promise.all([
         userClient.fetchAllUsers(),
-        reviewClient.findAllReviews(),
-        movieClient.fetchAllMovies()
+        reviewClient.findAllReviews()
       ]);
 
       setUsers(usersRes);
       setReviews(reviewsRes);
-      setMovies(moviesRes);
     } catch (err) {
       setError('Failed to fetch data. Please try again later.');
       console.error('Error fetching data:', err);
@@ -82,21 +90,6 @@ export default function Admin() {
     }
   };
 
-  // const toggleFeaturedMovie = async (movieId: string) => {
-  //   try {
-  //     const movie = movies.find(m => m._id === movieId);
-  //     if (!movie) return;
-
-  //     const updatedMovie = await axios.patch(`${API_BASE_URL}/movies/${movieId}`, {
-  //       featured: !movie.featured
-  //     });
-  //     setMovies(movies.map(m => m._id === movieId ? updatedMovie.data : m));
-  //   } catch (err) {
-  //     setError('Failed to update movie. Please try again.');
-  //     console.error('Error updating movie:', err);
-  //   }
-  // };
-
   const ConfirmationModal = ({ onConfirm, onCancel, message }: { onConfirm: () => void, onCancel: () => void, message: string }) => (
     <div className="modal-overlay">
       <div className="modal-content">
@@ -114,106 +107,86 @@ export default function Admin() {
     <div className="admin-dashboard">
       <h1>Admin Dashboard</h1>
       <div className="dashboard-content">
-        <div className="dashboard-column">
-          <h2>Users</h2>
-          <table className='user-table'>
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Role</th>
-                <th>Reputation</th>
-                <th>Action</th>
-              </tr>
-            </thead>
-            <tbody>
-              {users?.map(user => (
-                <tr key={user._id}>
-                  <td>{user.name}</td>
-                  <td>
-                    <select
-                      defaultValue={user.role}
-                      onChange={(e) => handleUpdateUser({ ...user, role: e.target.value })}
-                    >
-                      <option value="VIEWER">Viewer</option>
-                      <option value="CRITIC">Critic</option>
-                      <option value="ADMIN">Admin</option>
-                    </select>
-                  </td>
-                  <td>
-                    <input
-                      className="reputation-input"
-                      defaultValue={user.reputation}
-                      onKeyDown={(e) => handleReputationKeyPress(e, user)}
-                    />
-                  </td>
-                  <td>
-                    <button onClick={() => setConfirmAction({
-                      action: () => removeUser(user),
-                      message: `Are you sure you want to remove ${user.name}?`
-                    })}>
-                      Remove
-                    </button>
-                  </td>
+        {adminPermissions.includes('manage_users') && (
+          <div className="dashboard-column">
+            <h2>Users</h2>
+            <table className='user-table'>
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Role</th>
+                  <th>Reputation</th>
+                  <th>Action</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-        <div className="dashboard-column">
-          <h2>Reviews</h2>
-          <table className='reviews-table'>
-            <thead>
-              <tr>
-                <th>User Name</th>
-                <th>Movie Title</th>
-                <th>Rating</th>
-                <th>Action</th>
-              </tr>
-            </thead>
-            <tbody>
-              {reviews?.map(review => (
-                <tr key={review._id}>
-                  <td>{review.author}</td>
-                  <td>{review.movie.title}</td>
-                  <td>{review.rating}</td>
-                  <td>
-                    <button onClick={() => setConfirmAction({
-                      action: () => removeReview(review._id),
-                      message: 'Are you sure you want to remove this review?'
-                    })}>
-                      Remove
-                    </button>
-                  </td>
+              </thead>
+              <tbody>
+                {users.map(user => (
+                  <tr key={user._id}>
+                    <td>{user.name}</td>
+                    <td>
+                      <select
+                        defaultValue={user.role}
+                        onChange={(e) => handleUpdateUser({ ...user, role: e.target.value })}
+                      >
+                        <option value="VIEWER">Viewer</option>
+                        <option value="CRITIC">Critic</option>
+                        <option value="ADMIN">Admin</option>
+                      </select>
+                    </td>
+                    <td>
+                      <input
+                        className="reputation-input"
+                        defaultValue={user.reputation}
+                        onKeyDown={(e) => handleReputationKeyPress(e, user)}
+                      />
+                    </td>
+                    <td>
+                      <button onClick={() => setConfirmAction({
+                        action: () => removeUser(user),
+                        message: `Are you sure you want to remove ${user.name}?`
+                      })}>
+                        Remove
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+
+              </tbody>
+            </table>
+          </div>
+        )}
+        {adminPermissions.includes('manage_content') && (
+          <div className="dashboard-column">
+            <h2>Reviews</h2>
+            <table className='reviews-table'>
+              <thead>
+                <tr>
+                  <th>User Name</th>
+                  <th>Movie Title</th>
+                  <th>Rating</th>
+                  <th>Action</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-        <div className="dashboard-column">
-          <h2>Movies</h2>
-          <table className='movies-table'>
-            <thead>
-              <tr>
-                <th>Title</th>
-                <th>Featured</th>
-                <th>Action</th>
-              </tr>
-            </thead>
-            <tbody>
-              {movies?.map(movie => (
-                <tr key={movie._id}>
-                  <td>{movie.title}</td>
-                  <td>{movie.featured ? 'Yes' : 'No'}</td>
-                  {/* <td>
-                    <button onClick={() => toggleFeaturedMovie(movie._id)}>
-                      {movie.featured ? 'Unfeature' : 'Feature'}
-                    </button>
-                  </td> */}
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody>
+                {reviews.map(review => (
+                  <tr key={review._id}>
+                    <td>{review.author}</td>
+                    <td>{review.movie?.title || 'N/A'}</td>
+                    <td>{review.rating}</td>
+                    <td>
+                      <button onClick={() => setConfirmAction({
+                        action: () => removeReview(review._id),
+                        message: 'Are you sure you want to remove this review?'
+                      })}>
+                        Remove
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
       {confirmAction && (
         <ConfirmationModal

--- a/src/services/adminService.ts
+++ b/src/services/adminService.ts
@@ -1,0 +1,54 @@
+import axios from 'axios';
+
+const REMOTE_SERVER = process.env.REACT_APP_REMOTE_SERVER;
+const ADMINS_API = `${REMOTE_SERVER}/api/admins`;
+
+export const fetchAllAdmins = async () => {
+  const { data } = await axios.get(ADMINS_API);
+  return data;
+};
+
+export const findAdminByUserId = async (adminId: any) => {
+  const { data } = await axios.get(`${ADMINS_API}/${adminId}`);
+  return data;
+};
+
+export const createAdmin = async (admin: any) => {
+  const response = await axios.post(ADMINS_API, admin);
+  return response.data;
+};
+
+export const updateAdmin = async (admin: any) => {
+  const response = await axios.put(`${ADMINS_API}/${admin._id}`, admin);
+  return response.data;
+};
+
+export const deleteAdmin = async (adminId: string) => {
+  const response = await axios.delete(`${ADMINS_API}/${adminId}`);
+  return response.data;
+};
+
+export const addAdminAction = async (adminId: string, action: any) => {
+  const response = await axios.post(`${ADMINS_API}/${adminId}/actions`, action);
+  return response.data;
+};
+
+export const findAdminsByPermission = async (permission: string) => {
+  const { data } = await axios.get(`${ADMINS_API}/permission/${permission}`);
+  return data;
+};
+
+export const addPermissionToAdmin = async (adminId: string, permission: string) => {
+  const response = await axios.post(`${ADMINS_API}/${adminId}/permissions`, { permission });
+  return response.data;
+};
+
+export const removePermissionFromAdmin = async (adminId: string, permission: string) => {
+  const response = await axios.delete(`${ADMINS_API}/${adminId}/permissions/${permission}`);
+  return response.data;
+};
+
+export const fetchAdminPermissions = async (adminId: string) => {
+  const response = await axios.get(`${ADMINS_API}/${adminId}/permissions`);
+  return response.data;
+};

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+
 const REMOTE_SERVER = process.env.REACT_APP_REMOTE_SERVER;
 const USERS_API = `${REMOTE_SERVER}/api/users`;
 


### PR DESCRIPTION
Allows for filtering admin dashboard based on permissions, as well as edited NavBar to only show admin icon for admins

non-admin user login
![image](https://github.com/user-attachments/assets/20e187c4-237c-4eb7-ade6-5f61ca8ca476)

normal admin
![image](https://github.com/user-attachments/assets/d069314e-0ee3-4d8e-96ce-e38f0366f1bf)

super admin
![image](https://github.com/user-attachments/assets/b9bce04f-7d1e-4772-bf7b-735534a4ca5f)
